### PR TITLE
support password with space chars

### DIFF
--- a/src/telegram.cpp
+++ b/src/telegram.cpp
@@ -468,6 +468,7 @@ void Telegram::OnAuthStateUpdate()
         std::cout << "Enter authentication password: ";
         std::string password;
         std::cin >> password;
+        std::getline(std::cin, password);
         SendQuery(td::td_api::make_object<td::td_api::checkAuthenticationPassword>(password),
                   CreateAuthQueryHandler());
       }


### PR DESCRIPTION
Currently program gets only part of password before the space characters. Fixed with patch provided.