### PR TITLE
Added the clang dependency for Fedora/RHEL systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Fedora
 ------
 **Dependencies**
 
-    sudo dnf install ccache file-devel file-libs gperf readline-devel clang golang
+    sudo dnf install ccache file-devel file-libs gperf readline-devel clang golang libsqlite3x-devel libsqlite3x libsq3-devel
 
 **Source**
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Fedora
 ------
 **Dependencies**
 
-    sudo dnf install ccache file-devel file-libs gperf readline-devel clang
+    sudo dnf install ccache file-devel file-libs gperf readline-devel clang golang
 
 **Source**
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Fedora
 ------
 **Dependencies**
 
-    sudo dnf install ccache file-devel file-libs gperf readline-devel
+    sudo dnf install ccache file-devel file-libs gperf readline-devel clang
 
 **Source**
 


### PR DESCRIPTION
If the `clang` package is not present, the following error occurs when running the informed command:

```
$ mkdir -p build && cd build && cmake .. && make -s
-- The CXX compiler identification is unknown
CMake Error at CMakeLists.txt:3 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.


-- Configuring incomplete, errors occurred!
See also "/home/alolivei/GitHub/myrepos/nchat/build/CMakeFiles/CMakeOutput.log".
See also "/home/alolivei/GitHub/myrepos/nchat/build/CMakeFiles/CMakeError.log".
```