### PR TITLE
Support displaying muted messages at end of chat list

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,10 @@ example `w3m -o confirm_qq=false '%1'` and `see '%1'`.
 
 Specifies whether to display chat list. Controlled by Ctrl-l in run-time.
 
+### list_muted_last
+
+Specifies whether to put muted messages at the end of chat list.
+
 ### list_width
 
 Specifies width of chat list.

--- a/src/uiconfig.cpp
+++ b/src/uiconfig.cpp
@@ -35,6 +35,7 @@ void UiConfig::Init()
     { "home_fetch_all", "0" },
     { "link_open_command", "" },
     { "list_enabled", "1" },
+    { "list_muted_last", "0" },
     { "list_width", "14" },
     { "mark_read_on_view", "1" },
     { "mark_read_when_inactive", "0" },

--- a/src/uimodel.cpp
+++ b/src/uimodel.cpp
@@ -2112,10 +2112,31 @@ bool UiModel::Process()
 
 void UiModel::SortChats()
 {
+  static const bool listMutedLast = UiConfig::GetBool("list_muted_last");
   std::sort(m_ChatVec.begin(), m_ChatVec.end(),
             [&](const std::pair<std::string, std::string>& lhs, const std::pair<std::string, std::string>& rhs) -> bool
   {
-    return m_ChatInfos[lhs.first][lhs.second].lastMessageTime > m_ChatInfos[rhs.first][rhs.second].lastMessageTime;
+    if (listMutedLast)
+    {
+      bool lhsMuted = m_ChatInfos[lhs.first][lhs.second].isMuted;
+      bool rhsMuted = m_ChatInfos[rhs.first][rhs.second].isMuted;
+      if (lhsMuted && !rhsMuted)
+      {
+        return false;
+      }
+      else if (!lhsMuted && rhsMuted)
+      {
+        return true;
+      }
+      else
+      {
+        return m_ChatInfos[lhs.first][lhs.second].lastMessageTime > m_ChatInfos[rhs.first][rhs.second].lastMessageTime;
+      }
+    }
+    else
+    {
+      return m_ChatInfos[lhs.first][lhs.second].lastMessageTime > m_ChatInfos[rhs.first][rhs.second].lastMessageTime;
+    }
   });
 
   if (!m_ChatVec.empty())


### PR DESCRIPTION
Add a configurable option to display muted messages at the end of chat list. The option can be toggled by setting a bool option 'list_muted_last' in ui.conf. The option is disabled by default.