### PR TITLE
sort contacts by last message time

### DIFF
--- a/src/uimodel.h
+++ b/src/uimodel.h
@@ -67,6 +67,7 @@ public:
   bool Process();
 
   std::string GetLastMessageId(const std::string& p_ProfileId, const std::string& p_ChatId);
+  ChatInfo* GetChatInfo(const std::string& p_ProfileId, const std::string& p_ContactId);
   void UpdateChatInfoLastMessageTime(const std::string& p_ProfileId, const std::string& p_ChatId);
   void UpdateChatInfoIsUnread(const std::string& p_ProfileId, const std::string& p_ChatId);
   std::string GetContactName(const std::string& p_ProfileId, const std::string& p_ChatId);
@@ -120,6 +121,8 @@ public:
 
   static bool IsAttachmentDownloaded(const FileInfo& p_FileInfo);
   static bool IsAttachmentDownloadable(const FileInfo& p_FileInfo);
+
+  bool CompareChats(const ChatInfo& lhsChatInfo, const ChatInfo& rhsChatInfo);
 
 private:
   void SortChats();


### PR DESCRIPTION
### Issue

The contact list dialog is always sorted alphabetically because not all contacts have a chat for which to look a the last message time

### Solution

Allow to sort contacts by last message time when they have a chat, and list the ones with no chat at the bottom sorted alphabetically
