### PR TITLE
docs: readd alternative(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,7 +1069,7 @@ Alternatives
 Other terminal-based Telegram/WhatsApp clients:
 
 - Telegram: [tgt](https://github.com/FedericoBruzzone/tgt)
-- WhatsApp: none currently maintained known
+- WhatsApp: [whatscli](https://github.com/normen/whatscli)
 
 
 Keywords

--- a/README.md
+++ b/README.md
@@ -1064,6 +1064,14 @@ Please refer to [Contributing Guidelines](/doc/CONTRIBUTING.md) and
 [Design Notes](/doc/DESIGN.md).
 
 
+Alternatives
+============
+Other terminal-based Telegram/WhatsApp clients:
+
+- Telegram: [tgt](https://github.com/FedericoBruzzone/tgt)
+- WhatsApp: none currently maintained known
+
+
 Keywords
 ========
 command line, console-based, linux, macos, chat client, ncurses, telegram,


### PR DESCRIPTION
I happened to see that the Alternatives section was removed from the README as of `00bcfa4`.
While it's perfectly sensible, as the one that was listed is no longer maintained (also functioning?), but another, maintained and working alternative does exist for Telegram, which should be listed I guess.
Also IMO it's worth mentioning that there aren't any working WhatsApp tui alternatives (as far as I know).
