### PR TITLE
WIP: Initial support for right-aligned outgoing messages #376

### DIFF
--- a/src/uihistoryview.cpp
+++ b/src/uihistoryview.cpp
@@ -90,9 +90,9 @@ void UiHistoryView::Draw()
   bool firstMessage = true;
   int y = m_PaddedH - 1;
   int minPadding = m_PaddedW / 4;
-  int padding = 0;
   for (auto it = std::next(messageVec.begin(), messageOffset); it != messageVec.end(); ++it)
   {
+    int padding = 0;
     bool isSelectedMessage = firstMessage && m_Model->GetSelectMessageActiveLocked();
 
     auto msgIt = messages.find(*it);
@@ -138,7 +138,7 @@ void UiHistoryView::Draw()
       }
       else
       {
-          padding = std::max(static_cast<size_t>(minPadding), m_PaddedW - text.length());
+          padding = std::max(static_cast<size_t>(minPadding), m_PaddedW - text.length() - 1);
       }
       if (msg.isOutgoing) {
           wlines = StrUtil::WordWrap(StrUtil::ToWString(text), m_PaddedW - padding, false, false, false, 2);

--- a/src/uihistoryview.cpp
+++ b/src/uihistoryview.cpp
@@ -89,6 +89,8 @@ void UiHistoryView::Draw()
 
   bool firstMessage = true;
   int y = m_PaddedH - 1;
+  int minPadding = m_PaddedW / 4;
+  int padding = 0;
   for (auto it = std::next(messageVec.begin(), messageOffset); it != messageVec.end(); ++it)
   {
     bool isSelectedMessage = firstMessage && m_Model->GetSelectMessageActiveLocked();
@@ -130,7 +132,26 @@ void UiHistoryView::Draw()
         text = StrUtil::Textize(text);
       }
 
-      wlines = StrUtil::WordWrap(StrUtil::ToWString(text), m_PaddedW, false, false, false, 2);
+      if (text.length() >= static_cast<size_t>(m_PaddedW)) 
+      {
+          padding = minPadding;
+      }
+      else
+      {
+          padding = std::max(static_cast<size_t>(minPadding), m_PaddedW - text.length());
+      }
+      if (msg.isOutgoing) {
+          wlines = StrUtil::WordWrap(StrUtil::ToWString(text), m_PaddedW - padding, false, false, false, 2);
+          for (auto wline = wlines.rbegin(); wline != wlines.rend(); ++wline)
+          {
+              std::wstring leftPad = StrUtil::ToWString(std::string(padding, ' '));
+              wline->insert(0, leftPad);
+          }
+      }
+      else 
+      {
+          wlines = StrUtil::WordWrap(StrUtil::ToWString(text), m_PaddedW - padding, false, false, false, 2);
+      }
     }
 
     // Quoted message
@@ -414,6 +435,10 @@ void UiHistoryView::Draw()
         L" user " + StrUtil::ToWString(msg.senderId);
     }
 
+    if (msg.isOutgoing)
+    {
+        wheader.insert(0, StrUtil::ToWString(std::string(padding, ' ')));
+    }
     std::wstring wdisp = StrUtil::TrimPadWString(wheader, m_PaddedW);
     mvwaddnwstr(m_PaddedWin, y, 0, wdisp.c_str(), std::min((int)wdisp.size(), m_PaddedW));
 

--- a/src/uihistoryview.cpp
+++ b/src/uihistoryview.cpp
@@ -142,6 +142,17 @@ void UiHistoryView::Draw()
       }
       if (msg.isOutgoing) {
           wlines = StrUtil::WordWrap(StrUtil::ToWString(text), m_PaddedW - padding, false, false, false, 2);
+          padding = [&]()
+          {
+              size_t maxWidth = 0;
+              for (auto wline = wlines.rbegin(); wline != wlines.rend(); ++wline)
+              {
+                  maxWidth = wline->length() > maxWidth ? wline->length() : maxWidth;
+              }
+              int newPadding = std::max(padding, static_cast<int>(m_PaddedW - maxWidth));
+              // return static_cast<int>(maxWidth); // this is a safe cast because necessarily maxWidth < m_PaddedW
+              return newPadding;
+          }();
           for (auto wline = wlines.rbegin(); wline != wlines.rend(); ++wline)
           {
               std::wstring leftPad = StrUtil::ToWString(std::string(padding, ' '));

--- a/src/uihistoryview.cpp
+++ b/src/uihistoryview.cpp
@@ -437,7 +437,8 @@ void UiHistoryView::Draw()
 
     if (msg.isOutgoing)
     {
-        wheader.insert(0, StrUtil::ToWString(std::string(padding, ' ')));
+        int headerPadding = std::min(static_cast<size_t>(padding), m_PaddedW - wheader.length() - 1);
+        wheader.insert(0, StrUtil::ToWString(std::string(headerPadding, ' ')));
     }
     std::wstring wdisp = StrUtil::TrimPadWString(wheader, m_PaddedW);
     mvwaddnwstr(m_PaddedWin, y, 0, wdisp.c_str(), std::min((int)wdisp.size(), m_PaddedW));


### PR DESCRIPTION
I really liked the suggestion in #376 so I went ahead and tried making it happen.

I don't think this approach is particularly hacky, but my C++ is very rusty, so I'd like some review of this approach before I keep working on it.
Right now everything is hardcoded, but I will implement a config option for this if everything else looks all right. I was thinking one option would control both whether the feature is on and the amount of "padding" on both sides, something like `outgoing_messages_left_padding`, which would default to 0 thus disabling this feature. I also found that it's better to have that as a percentage of the window width, rather than a flat number.

<img width="1015" height="707" alt="2025-09-08T16:43:27,052532373+02:00" src="https://github.com/user-attachments/assets/01aebd9d-c496-4fde-8b06-b9efa747efb7" />
