### PR TITLE
Initial support for color-coding unread messages

### DIFF
--- a/src/uicolorconfig.cpp
+++ b/src/uicolorconfig.cpp
@@ -53,6 +53,8 @@ void UiColorConfig::Init()
     { "listborder_attr", "" },
     { "listborder_color_bg", "" },
     { "listborder_color_fg", "" },
+    { "list_color_unread_fg", "" },
+    { "list_color_unread_bg", "" },
 
     { "history_text_attr", "" },
     { "history_text_attr_selected", "reverse" },

--- a/src/uilistview.cpp
+++ b/src/uilistview.cpp
@@ -51,6 +51,7 @@ void UiListView::Draw()
   static int colorPair = UiColorConfig::GetColorPair("list_color");
   static int attribute = UiColorConfig::GetAttribute("list_attr");
   static int attributeSelected = UiColorConfig::GetAttribute("list_attr_selected");
+  static int colorPairUnread = UiColorConfig::GetColorPair("list_color_unread");
 
   int index = std::max(0, m_Model->GetCurrentChatIndexLocked());
   const std::vector<std::pair<std::string, std::string>>& p_ChatVec = m_Model->GetChatVecLocked();
@@ -94,13 +95,17 @@ void UiListView::Draw()
       std::wstring wname = StrUtil::ToWString(name).substr(0, m_PaddedW);
       wname = StrUtil::TrimPadWString(wname, m_PaddedW);
 
+      if (unreads[i])
+      {
+          wattron(m_PaddedWin, colorPairUnread);
+      }
       mvwaddnwstr(m_PaddedWin, y, 0, wname.c_str(), wname.size());
-
       if (unreads[i])
       {
         static const std::string unreadIndicator = " " + UiConfig::GetStr("unread_indicator");
         static const std::wstring wunread = StrUtil::ToWString(unreadIndicator);
         mvwaddnwstr(m_PaddedWin, y, (m_PaddedW - StrUtil::WStringWidth(wunread)), wunread.c_str(), wunread.size());
+        wattroff(m_PaddedWin, colorPairUnread);
       }
 
       if (i == index)


### PR DESCRIPTION
This is the easiest bit of #395: adding separate coloring for unread messages.
Groups and other features, I fear, would be much harder.