### PR TITLE
Dev feature: allow CMAKEARGS to be passed to make.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,17 @@ Using make.sh script
 If using macOS, Alpine, Arch, Fedora, Gentoo, Raspbian, Ubuntu or Void, one
 can use the `make.sh` script provided.
 
+> [!TIP]
+> You can pass arguments to the build script by setting CMAKEARGS environment variable
+
 **Dependencies**
 
     ./make.sh deps
 
 **Build / Install**
 
-    ./make.sh build && ./make.sh install
+    ./make.sh build
+    sudo ./make.sh install  # depending on your prefix dir, you can skip sudo
 
 Manually
 --------

--- a/make.sh
+++ b/make.sh
@@ -50,7 +50,7 @@ INSTALL="0"
 SRC="0"
 BUMP="0"
 YES=""
-CMAKEARGS=""
+CMAKEARGS="${CMAKEARGS:-}"
 
 if [[ "${#}" == "0" ]]; then
   show_usage


### PR DESCRIPTION
I wanted to set my `-DCMAKE_INSTALL_PREFIX` to ~/.local, there's already a CMAKEARGS it just doesn't read from env