### PR TITLE
Increase auto_compose llm request timeout

### DIFF
--- a/src/compose
+++ b/src/compose
@@ -99,7 +99,7 @@ def send_request(payload: dict, api_url: str, api_key: str, verbose: bool=False)
     )
 
     try:
-        with urllib.request.urlopen(req, timeout=10) as resp:
+        with urllib.request.urlopen(req, timeout=60*2) as resp:
             body = resp.read().decode("utf-8")
             result = json.loads(body)
     except urllib.error.HTTPError as e:


### PR DESCRIPTION
For models like gpt-5-nano the request usually takes longer than 10 seconds, so the http request times out and the auto compose fails. Increased the timeout to 2 mins to support better and slower models.