### PR TITLE
add support to undo cleared input

### DIFF
--- a/src/uimodel.cpp
+++ b/src/uimodel.cpp
@@ -384,8 +384,7 @@ void UiModel::Impl::EntryKeyHandler(wint_t p_Key)
   }
   else if (p_Key == keyClear)
   {
-    entryStr.clear();
-    entryPos = 0;
+    Clear();
     SetTyping(profileId, chatId, true);
   }
   else if (p_Key == keyLinebreak)
@@ -3009,8 +3008,23 @@ void UiModel::Impl::Clear()
   std::string chatId = m_CurrentChat.second;
   int& entryPos = m_EntryPos[profileId][chatId];
   std::wstring& entryStr = m_EntryStr[profileId][chatId];
-  entryStr.clear();
-  entryPos = 0;
+
+  if (entryStr.empty())
+  {
+    if (!m_EntryStrUndo[profileId][chatId].empty())
+    {
+      entryStr = m_EntryStrUndo[profileId][chatId];
+      entryPos = m_EntryPosUndo[profileId][chatId];
+      m_EntryStrUndo[profileId][chatId].clear();
+    }
+  }
+  else
+  {
+    m_EntryStrUndo[profileId][chatId] = entryStr;
+    m_EntryPosUndo[profileId][chatId] = entryPos;
+    entryStr.clear();
+    entryPos = 0;
+  }
 
   UpdateEntry();
 }

--- a/src/uimodel.h
+++ b/src/uimodel.h
@@ -253,6 +253,9 @@ private:
     std::unordered_map<std::string, std::unordered_map<std::string, std::wstring>> m_EntryStr;
     std::unordered_map<std::string, std::unordered_map<std::string, int>> m_EntryPos;
 
+    std::unordered_map<std::string, std::unordered_map<std::string, std::wstring>> m_EntryStrUndo;
+    std::unordered_map<std::string, std::unordered_map<std::string, int>> m_EntryPosUndo;
+
     std::unordered_map<std::string, std::unordered_map<std::string, std::set<std::string>>> m_UsersTyping;
     std::unordered_map<std::string, std::unordered_map<std::string, bool>> m_UserOnline;
     std::unordered_map<std::string, std::unordered_map<std::string, int64_t>> m_UserTimeSeen;


### PR DESCRIPTION
Description:
  This PR implements a toggle-like undo feature for the message entry field to prevent accidental data loss.

   * Behavior:
       * Pressing Ctrl+C (or the configured Clear key) once deletes the current message draft, saving it to a temporary undo buffer.
       * Pressing Ctrl+C again (while the input is empty) restores the previously deleted text and cursor position.
