### PR TITLE
build: link against resolv on macOS

### DIFF
--- a/lib/wmchat/CMakeLists.txt
+++ b/lib/wmchat/CMakeLists.txt
@@ -28,7 +28,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   add_compile_definitions(_XOPEN_SOURCE_EXTENDED)
   FIND_LIBRARY(CARBON_LIBRARY CoreFoundation)
   FIND_LIBRARY(CARBON_LIBRARY Security)
-  target_link_libraries(wmchat PUBLIC "-framework CoreFoundation" "-framework Security")
+  target_link_libraries(wmchat PUBLIC "-framework CoreFoundation" "-framework Security" resolv)
 endif()
 
 # Headers


### PR DESCRIPTION
Fixes https://github.com/d99kris/nchat/issues/482 Go 1.26+ linking error on macOS.