### PR TITLE
(Telegram) Implement local message deletion.

### DIFF
--- a/lib/common/src/protocol.h
+++ b/lib/common/src/protocol.h
@@ -280,6 +280,7 @@ public:
   std::string chatId;
   std::string senderId; // only required for wmchat
   std::string msgId;
+  bool revoke = true;
 };
 
 class DeleteChatRequest : public RequestMessage

--- a/lib/tgchat/src/tgchat.cpp
+++ b/lib/tgchat/src/tgchat.cpp
@@ -1044,7 +1044,7 @@ void TgChat::Impl::PerformRequest(std::shared_ptr<RequestMessage> p_RequestMessa
         auto delete_messages = td::td_api::make_object<td::td_api::deleteMessages>();
         delete_messages->chat_id_ = chatId;
         delete_messages->message_ids_ = msgIds;
-        delete_messages->revoke_ = true; // delete for all (if possible)
+        delete_messages->revoke_ = deleteMessageRequest->revoke;
 
         SendQuery(std::move(delete_messages),
                   [this, deleteMessageRequest](Object object)

--- a/src/uihelpview.cpp
+++ b/src/uihelpview.cpp
@@ -119,6 +119,7 @@ void UiHelpView::Draw()
     AppendHelpItem("down", "NextMsg", helpItems);
 
     AppendHelpItem("delete_msg", "DelMsg", helpItems);
+    AppendHelpItem("delete_msg_local", "DelLoc", helpItems);
     AppendHelpItem("edit_msg", "EditMsg", helpItems);
     AppendHelpItem("open", "OpenFile", helpItems);
     AppendHelpItem("save", "SaveFile", helpItems);

--- a/src/uikeyconfig.cpp
+++ b/src/uikeyconfig.cpp
@@ -237,6 +237,7 @@ void UiKeyConfig::Init(bool p_MapKeys)
     { "unread_chat", "KEY_CTRLF" },
     { "send_msg", "KEY_CTRLX" },
     { "delete_msg", "KEY_CTRLD" },
+    { "delete_msg_local", "\\33\\104" }, // alt/opt-shift-d
     { "delete_chat", "\\33\\144" }, // alt/opt-d
     { "open", "KEY_CTRLV" },
     { "open_link", "KEY_CTRLW" },

--- a/src/uimodel.cpp
+++ b/src/uimodel.cpp
@@ -899,7 +899,7 @@ void UiModel::Impl::DownloadAttachment(const std::string& p_ProfileId, const std
   mit->second.fileInfo = ProtocolUtil::FileInfoToHex(fileInfo);
 }
 
-void UiModel::Impl::OnKeyDeleteMsg()
+void UiModel::Impl::OnKeyDeleteMsg(bool p_Revoke)
 {
   AnyUserKeyInput();
 
@@ -932,6 +932,7 @@ void UiModel::Impl::OnKeyDeleteMsg()
   deleteMessageRequest->chatId = chatId;
   deleteMessageRequest->senderId = senderId;
   deleteMessageRequest->msgId = msgId;
+  deleteMessageRequest->revoke = p_Revoke;
   SendProtocolRequest(profileId, deleteMessageRequest);
 }
 
@@ -4009,6 +4010,7 @@ void UiModel::KeyHandler(wint_t p_Key)
   static wint_t keySelectEmoji = UiKeyConfig::GetKey("select_emoji");
   static wint_t keySelectContact = UiKeyConfig::GetKey("select_contact");
   static wint_t keyTransfer = UiKeyConfig::GetKey("transfer");
+  static wint_t keyDeleteMsgLocal = UiKeyConfig::GetKey("delete_msg_local");
   static wint_t keyDeleteMsg = UiKeyConfig::GetKey("delete_msg");
   static wint_t keyDeleteChat = UiKeyConfig::GetKey("delete_chat");
   static wint_t keyEditMsg = UiKeyConfig::GetKey("edit_msg");
@@ -4150,7 +4152,11 @@ void UiModel::KeyHandler(wint_t p_Key)
   }
   else if (p_Key == keyDeleteMsg)
   {
-    OnKeyDeleteMsg();
+    OnKeyDeleteMsg(true);
+  }
+  else if (p_Key == keyDeleteMsgLocal)
+  {
+    OnKeyDeleteMsg(false);
   }
   else if (p_Key == keyDeleteChat)
   {
@@ -4832,7 +4838,7 @@ bool UiModel::MessageDialog(const std::string& p_Title, const std::string& p_Tex
   return rv;
 }
 
-void UiModel::OnKeyDeleteMsg()
+void UiModel::OnKeyDeleteMsg(bool p_Revoke)
 {
   // Pre-req
   {
@@ -4851,7 +4857,7 @@ void UiModel::OnKeyDeleteMsg()
   }
 
   std::unique_lock<owned_mutex> lock(m_ModelMutex);
-  GetImpl().OnKeyDeleteMsg();
+  GetImpl().OnKeyDeleteMsg(p_Revoke);
 }
 
 void UiModel::OnKeyDeleteChat()

--- a/src/uimodel.h
+++ b/src/uimodel.h
@@ -60,7 +60,7 @@ private:
     void OnStatusUpdate(uint32_t p_Status);
     void DownloadAttachment(const std::string& p_ProfileId, const std::string& p_ChatId, const std::string& p_MsgId,
                             const std::string& p_FileId, DownloadFileAction p_DownloadFileAction);
-    void OnKeyDeleteMsg();
+    void OnKeyDeleteMsg(bool p_Revoke = true);
     void OnKeyDeleteChat();
     void OnKeyOpenMsg();
     bool GetMessageAttachmentPath(std::string& p_FilePath, DownloadFileAction p_DownloadFileAction);
@@ -378,7 +378,7 @@ private:
   void OnKeyFindNext();
   void OnKeyForwardMsg();
   bool MessageDialog(const std::string& p_Title, const std::string& p_Text, float p_WReq, float p_HReq);
-  void OnKeyDeleteMsg();
+  void OnKeyDeleteMsg(bool p_Revoke = true);
   void OnKeyDeleteChat();
   void OnKeySaveAttachment();
   void OnKeyEditMsg();


### PR DESCRIPTION
This PR adds the ability to delete messages locally without revoking them for everyone else, matching the official Telegram client's behavior. This change is currently relevant for Telegram; other protocols will handle the new shortcut identical to a normal message deletion and will not be affected.

Changes include:
- Extended `DeleteMessageRequest` with a `revoke` flag (defaults to `true`).
- Updated `tgchat` to pass `revoke` down to tdlib.
- Added `delete_msg_local` key binding mapped to `Alt-Shift-D` (`\33\104`).
- Exposed the new action via `UiModel` and registered it in the UI help menu as `DelLoc`.
`Ctrl+D` retains the default behavior of deleting for everyone, while `Alt-Shift-D` safely deletes messages only for the user on telegram.