### PR TITLE
fix: whatsapp archive lthash mismatch and UI history refresh

### DIFF
--- a/lib/wmchat/go/ext/nchat-whatsmeow.patch
+++ b/lib/wmchat/go/ext/nchat-whatsmeow.patch
@@ -1,5 +1,24 @@
 Base-Commit: fc65416c22c47e15be1daf2e2d62deaba6881591
 Base-Branch: 
+diff --git a/appstate.go b/appstate.go
+index beacc44..4188264 100644
+--- a/appstate.go
++++ b/appstate.go
+@@ -161,6 +161,14 @@ func (cli *Client) applyAppStatePatches(
+ 	if err != nil {
+ 		if errors.Is(err, appstate.ErrKeyNotFound) {
+ 			go cli.requestMissingAppStateKeys(context.WithoutCancel(ctx), patches)
++		} else if errors.Is(err, appstate.ErrMismatchingLTHash) {
++			cli.Log.Warnf("LTHash mismatch for %s, requesting recovery", name)
++			go func() {
++				_, errReq := cli.SendPeerMessage(context.WithoutCancel(ctx), BuildAppStateRecoveryRequest(name))
++				if errReq != nil {
++					cli.Log.Errorf("Failed to send app state recovery request for %s: %v", name, errReq)
++				}
++			}()
+ 		}
+ 		return state, fmt.Errorf("failed to decode app state %s patches: %w", name, err)
+ 	}
 diff --git a/download.go b/download.go
 index 16b6108..6bdbd32 100644
 --- a/download.go

--- a/lib/wmchat/go/ext/nchat-whatsmeow.patch
+++ b/lib/wmchat/go/ext/nchat-whatsmeow.patch
@@ -1,5 +1,26 @@
 Base-Commit: 662ad1dc6900ffe1b1a2a6bc0fca01cba488d747
 Base-Branch: 
+diff --git a/appstate.go b/appstate.go
+index 2d6a36f..38031d2 100644
+--- a/appstate.go
++++ b/appstate.go
+@@ -161,6 +161,14 @@ func (cli *Client) applyAppStatePatches(
+ 	if err != nil {
+ 		if errors.Is(err, appstate.ErrKeyNotFound) {
+ 			go cli.requestMissingAppStateKeys(context.WithoutCancel(ctx), patches)
++		} else if errors.Is(err, appstate.ErrMismatchingLTHash) {
++			cli.Log.Warnf("LTHash mismatch for %s, requesting recovery", name)
++			go func() {
++				_, errReq := cli.SendPeerMessage(context.WithoutCancel(ctx), BuildAppStateRecoveryRequest(name))
++				if errReq != nil {
++					cli.Log.Errorf("Failed to send app state recovery request for %s: %v", name, errReq)
++				}
++			}()
+ 		} else {
+ 			cli.dispatchEvent(&events.AppStateSyncError{Name: name, FullSync: fullSync, Error: err})
+ 		}
+ 		return state, fmt.Errorf("failed to decode app state %s patches: %w", name, err)
+ 	}
 diff --git a/download.go b/download.go
 index 0777de8..4f31c30 100644
 --- a/download.go

--- a/lib/wmchat/go/ext/whatsmeow/appstate.go
+++ b/lib/wmchat/go/ext/whatsmeow/appstate.go
@@ -161,6 +161,14 @@ func (cli *Client) applyAppStatePatches(
 	if err != nil {
 		if errors.Is(err, appstate.ErrKeyNotFound) {
 			go cli.requestMissingAppStateKeys(context.WithoutCancel(ctx), patches)
+		} else if errors.Is(err, appstate.ErrMismatchingLTHash) {
+			cli.Log.Warnf("LTHash mismatch for %s, requesting recovery", name)
+			go func() {
+				_, errReq := cli.SendPeerMessage(context.WithoutCancel(ctx), BuildAppStateRecoveryRequest(name))
+				if errReq != nil {
+					cli.Log.Errorf("Failed to send app state recovery request for %s: %v", name, errReq)
+				}
+			}()
 		}
 		return state, fmt.Errorf("failed to decode app state %s patches: %w", name, err)
 	}

--- a/lib/wmchat/go/ext/whatsmeow/appstate.go
+++ b/lib/wmchat/go/ext/whatsmeow/appstate.go
@@ -160,6 +160,14 @@ func (cli *Client) applyAppStatePatches(
 	if err != nil {
 		if errors.Is(err, appstate.ErrKeyNotFound) {
 			go cli.requestMissingAppStateKeys(context.WithoutCancel(ctx), patches)
+		} else if errors.Is(err, appstate.ErrMismatchingLTHash) {
+			cli.Log.Warnf("LTHash mismatch for %s, requesting recovery", name)
+			go func() {
+				_, errReq := cli.SendPeerMessage(context.WithoutCancel(ctx), BuildAppStateRecoveryRequest(name))
+				if errReq != nil {
+					cli.Log.Errorf("Failed to send app state recovery request for %s: %v", name, errReq)
+				}
+			}()
 		} else {
 			cli.dispatchEvent(&events.AppStateSyncError{Name: name, FullSync: fullSync, Error: err})
 		}

--- a/src/uimodel.cpp
+++ b/src/uimodel.cpp
@@ -2139,11 +2139,16 @@ void UiModel::Impl::MessageHandler(std::shared_ptr<ServiceMessage> p_ServiceMess
           getChatsRequest->chatIds.insert(chatId);
           SendProtocolRequest(profileId, getChatsRequest);
 
+          // clear previously requested message ids, as prior requests may have been
+          // silently dropped by NewMessagesNotify handler when chat was still archived
+          m_MsgFromIdsRequested[profileId][chatId].clear();
+
           // fetch messages so they're available when user selects this chat
           RequestMessages(profileId, chatId);
         }
         SortChats();
         UpdateList();
+        UpdateHistory();
         UpdateStatus();
       }
       break;

--- a/src/uimodel.cpp
+++ b/src/uimodel.cpp
@@ -2215,11 +2215,16 @@ void UiModel::Impl::MessageHandler(std::shared_ptr<ServiceMessage> p_ServiceMess
           getChatsRequest->chatIds.insert(chatId);
           SendProtocolRequest(profileId, getChatsRequest);
 
+          // clear previously requested message ids, as prior requests may have been
+          // silently dropped by NewMessagesNotify handler when chat was still archived
+          m_MsgFromIdsRequested[profileId][chatId].clear();
+
           // fetch messages so they're available when user selects this chat
           RequestMessages(profileId, chatId);
         }
         SortChats();
         UpdateList();
+        UpdateHistory();
         UpdateStatus();
       }
       break;


### PR DESCRIPTION
This PR addresses the issue where WhatsApp chats fail to sync their archive/unarchive state properly when modified from another device (e.g.,
  a phone) while nchat is offline or disconnected.

  What this fixes:
   1. ErrMismatchingLTHash in whatsmeow: When the local app state hash does not match the server's hash, whatsmeow previously failed silently on
      ErrMismatchingLTHash. This patch catches the error and explicitly sends a BuildAppStateRecoveryRequest to heal the local state.
     
   2. UI History Refresh (uimodel.cpp): When a chat is unarchived, the application sends a request for new messages. However, prior message
      requests might have been silently dropped by the NewMessagesNotify handler when the chat was still considered archived locally. This
      clears any previously requested message IDs and calls UpdateHistory() to ensure the UI accurately reflects any messages that arrived while
      the chat was archived.

