### PR TITLE
Add root check for installation command in make.sh

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -373,8 +373,14 @@ if [[ "${INSTALL}" == "1" ]]; then
     fi
   fi
 
-  echo "-- Using ${INSTALL_CMD:+$INSTALL_CMD }make install"
-  cd build && ${INSTALL_CMD} make install && cd .. || exiterr "install failed (${OS}), exiting."
+  # check if we are already root
+  if [ "$EUID" -ne 0 ]; then
+    echo "-- Using ${INSTALL_CMD:+$INSTALL_CMD }make install"
+    cd build && ${INSTALL_CMD} make install && cd .. || exiterr "install failed (${OS}), exiting."
+  else
+    echo "-- Using make install"
+    cd build &&  make install && cd .. || exiterr "install failed (${OS}), exiting."
+  fi
 fi
 
 # exit


### PR DESCRIPTION
It may cause problems in a pseudo root simulated environments. It happens during the installation phase with make.sh install

No 'su' binary found
SU_SEARCH_PATHS: /system/bin/su /debug_ramdisk/su /system/xbin/su /sbin/su /sbin/bin/su /system/sbin/su /su/xbin/su /su/bin/su /magisk/.core/bin/su sudo requires a 'su' binary that supports the '-c', '--shell', '--preserve-environment' and '--mount-master' options