### PR TITLE
use markdown extension for external editor temp file

### DIFF
--- a/src/uimodel.cpp
+++ b/src/uimodel.cpp
@@ -3682,7 +3682,7 @@ void UiModel::Impl::CallExternalEdit(const std::string& p_EditorCmd)
   int& entryPos = m_EntryPos[profileId][chatId];
 
   TerminalControlPause();
-  std::string tempPath = FileUtil::GetTempDir() + "/compose.txt";
+  std::string tempPath = FileUtil::GetTempDir() + "/compose.md";
   std::string composeStr = StrUtil::ToString(entryStr);
   FileUtil::WriteFile(tempPath, composeStr);
   const std::string cmd = p_EditorCmd + " " + tempPath;


### PR DESCRIPTION
## Summary
- use a markdown temp filename (`compose.md`) for the external editor flow
- keep the external edit behavior unchanged while enabling editor markdown detection/syntax support