### PR TITLE
fix the calculation of RAM in MEM to ensure MEM_MAX_THREADS works cor…

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -273,16 +273,22 @@ fi
 # make args
 if [[ "${BUILD}" == "1" ]] || [[ "${DEBUG}" == "1" ]]; then
   if [[ "${OS}" == "Linux" ]]; then
-    MEM=$(( $(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / 1000 / 1000 )) # in MB
+    MEM_BYTES=$(( $(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) ))
+    MEM_DIVISOR=$(( 1024 * 1024 )) # in bytes
   elif [[ "${OS}" == "Darwin" ]]; then
-    MEM=$(( $(sysctl -n hw.memsize) / 1000 / 1000 )) # in MB
+    MEM_BYTES=$(sysctl -n hw.memsize) # in bytes
+    MEM_DIVISOR=$(( 1024 * 1024 ))
   elif [[ "${OS}" == "OpenBSD" ]]; then
-    MEM=$(( $(sysctl -n hw.physmem) / 1000 / 1000 )) # in MB
+    MEM_BYTES=$(sysctl -n hw.physmem) # in bytes
+    MEM_DIVISOR=$(( 1024 * 1024 ))
   fi
-
-  MEM_NEEDED_PER_CORE="3500" # tdlib under g++ needs 3.5 GB
+  
+  # memory in MB rounded to nearest 512 
+  MEM=$(( (${MEM_BYTES} + ( 256 * ${MEM_DIVISOR} )) / ( 512 * ${MEM_DIVISOR}) * 512 ))
+  MEM_NEEDED_PER_CORE="3584" # tdlib under g++ needs 3.5 GB
+  
   if [[ "$(${CXX:-c++} -dM -E -x c++ - < /dev/null | grep CLANG_ATOMIC > /dev/null ; echo ${?})" == "0" ]]; then
-    MEM_NEEDED_PER_CORE="1500" # tdlib under clang++ needs 1.5 GB
+    MEM_NEEDED_PER_CORE="1536" # tdlib under clang++ needs 1.5 GB
   fi
 
   MEM_MAX_THREADS="$((${MEM} / ${MEM_NEEDED_PER_CORE}))"

--- a/make.sh
+++ b/make.sh
@@ -273,11 +273,11 @@ fi
 # make args
 if [[ "${BUILD}" == "1" ]] || [[ "${DEBUG}" == "1" ]]; then
   if [[ "${OS}" == "Linux" ]]; then
-    MEM="$(( $(($(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / (1000 * 1000 * 1000))) * 1000 ))" # in MB
+    MEM=$(( $(getconf _PHYS_PAGES) * $(getconf PAGE_SIZE) / 1000 / 1000 )) # in MB
   elif [[ "${OS}" == "Darwin" ]]; then
-    MEM="$(( $(($(sysctl -n hw.memsize) / (1000 * 1000 * 1000))) * 1000 ))" # in MB
+    MEM=$(( $(sysctl -n hw.memsize) / 1000 / 1000 )) # in MB
   elif [[ "${OS}" == "OpenBSD" ]]; then
-    MEM="$(( $(($(sysctl -n hw.physmem) / (1000 * 1000 * 1000))) * 1000 ))" # in MB
+    MEM=$(( $(sysctl -n hw.physmem) / 1000 / 1000 )) # in MB
   fi
 
   MEM_NEEDED_PER_CORE="3500" # tdlib under g++ needs 3.5 GB


### PR DESCRIPTION
Bash completely discards the remainder in this division; that is, if we run make.sh on a machine with a non-standard amount of RAM, for example, on SBC with 8.5 GB of RAM - then after this conversion, we’ll end up with exactly 8 GB, which is incorrect.